### PR TITLE
:bug: (handler) rename duplicate restart handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,5 +6,5 @@
 - name: restart x
   action: service name=x state=restarted enabled=yes
 
-- name: restart x
-  action: service name=x state=restarted enabled=yes
+- name: restart kiosk
+  action: service name=kiosk state=restarted enabled=yes


### PR DESCRIPTION
The "restart x" handler was defined twice but one of them should be "restart kiosk".

Fixes #1 